### PR TITLE
Speed up by ~15x

### DIFF
--- a/example/example.jl
+++ b/example/example.jl
@@ -200,7 +200,7 @@ function tick(model::Model, wil::NNMatrix, sents::Array, solver::Solver, tickite
 end
 
 
-maxIter =  50 # make this about 100_000 to run full model
+maxIter = 50 # make this about 100_000 to run full model
 trgppl = 1.1 # stop if this perplexity score is reached
 while tickiter < maxIter && ppl > trgppl
     model, wil, solver, tickiter, pplcurve, ppl = tick(model, wil, sents, solver, tickiter, pplcurve)
@@ -208,3 +208,7 @@ end
 @time while tickiter < 2*maxIter && ppl > trgppl
     model, wil, solver, tickiter, pplcurve, ppl = tick(model, wil, sents, solver, tickiter, pplcurve)
 end
+
+#using ProfileView
+#ProfileView.view()
+#readline()

--- a/example/example.jl
+++ b/example/example.jl
@@ -209,6 +209,7 @@ end
     model, wil, solver, tickiter, pplcurve, ppl = tick(model, wil, sents, solver, tickiter, pplcurve)
 end
 
+Profile.print(format=:flat)
 #using ProfileView
 #ProfileView.view()
 #readline()

--- a/example/example.jl
+++ b/example/example.jl
@@ -2,6 +2,7 @@ using RecurrentNN
 # reload("RecurrentNN.jl")
 # # global settings
 # const generator = "rnn" # can be 'rnn' or 'lstm'
+srand(12345)
 const generator = "lstm" # can be 'rnn' or 'lstm'
 const hiddensizes = [20,20] # list of sizes of hidden layers
 # const hiddensizes = [100] # uncomment to run full model
@@ -202,5 +203,8 @@ end
 maxIter =  50 # make this about 100_000 to run full model
 trgppl = 1.1 # stop if this perplexity score is reached
 while tickiter < maxIter && ppl > trgppl
+    model, wil, solver, tickiter, pplcurve, ppl = tick(model, wil, sents, solver, tickiter, pplcurve)
+end
+@time while tickiter < 2*maxIter && ppl > trgppl
     model, wil, solver, tickiter, pplcurve, ppl = tick(model, wil, sents, solver, tickiter, pplcurve)
 end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -26,10 +26,8 @@ function tanh(g::Graph, m::NNMatrix)
     if g.doBackprop
         push!(g.backprop,
               function ()
-                  for i = 1:m.n
-                      for j = 1:m.d
-                          @inbounds m.dw[i,j] += (1. - out.w[i,j]^2) * out.dw[i,j]
-                      end
+                  @inbounds for j = 1:m.d, i = 1:m.n
+                      m.dw[i,j] += (1. - out.w[i,j]^2) * out.dw[i,j]
                   end
               end )
     end
@@ -37,16 +35,15 @@ function tanh(g::Graph, m::NNMatrix)
 end
 
 function sigmoid(g::Graph, m::NNMatrix)
-    out = NNMatrix(m.n, m.d)
-    out.w = ones(m.w) ./ (ones(m.w) .+ exp(-m.w)) # sigmoid function
+    out = NNMatrix(m.n, m.d,
+            [1.0 / (1.0 + exp(-m.w[i,j])) for i in 1:m.n, j in m.d],
+            zeros(m.n, m.d))
     # backprop function
     if g.doBackprop
         push!(g.backprop,
               function ()
-                  for i = 1:m.n
-                      for j = 1:m.d
-                          @inbounds m.dw[i,j] +=  out.w[i,j] * (1. - out.w[i,j]) *  out.dw[i,j]
-                      end
+                  @inbounds for j = 1:m.d, i = 1:m.n
+                      m.dw[i,j] +=  out.w[i,j] * (1. - out.w[i,j]) *  out.dw[i,j]
                   end
               end )
     end
@@ -55,19 +52,15 @@ end
 
 function relu(g::Graph, m::NNMatrix)
     out = NNMatrix(m.n, m.d)
-    for i = 1:m.n
-      for j = 1:m.d
-          @inbounds out.w[i,j] = m.w[i,j] < 0. ? 0. :  m.w[i,j]
-      end
+    @inbounds for j = 1:m.d, i = 1:m.n
+        out.w[i,j] = m.w[i,j] < 0. ? 0. : m.w[i,j]
     end
     # backprop function
     if g.doBackprop
         push!(g.backprop,
           function ()
-              for i = 1:m.n
-                  for j = 1:m.d
-                      @inbounds m.dw[i,j] +=  m.w[i,j] < 0. ? 0 : out.dw[i,j]
-                  end
+              @inbounds for j = 1:m.d, i = 1:m.n
+                  m.dw[i,j] +=  m.w[i,j] < 0. ? 0 : out.dw[i,j]
               end
           end )
     end
@@ -75,41 +68,36 @@ function relu(g::Graph, m::NNMatrix)
 end
 
 function mul(g::Graph, m1::NNMatrix, m2::NNMatrix)
-    out = NNMatrix(m1.n, m2.d)
-#     println((m1.n, m2.d))
-    n = m1.n
-    d = m2.d
-    for i = 1:n
-        for j = 1:d
-            dot = 0.
-            for k = 1:m1.d
-                @inbounds dot += m1.w[i,k] * m2.w[k,j]
-            end
-            @inbounds out.w[i,j] = dot
-        end
-    end
+    out = NNMatrix(m1.n, m2.d, m1.w * m2.w, zeros(m1.n, m2.d))
 
     # backprop function
     if g.doBackprop
         push!(g.backprop,
             function ()
-                @inbounds for i = 1:m1.n # m1's num row
-                    for j = 1:m2.d # m2's num row
-                        b = out.dw[i,j]
-                        for k = 1:m1.d # m1's num col
-                              m1.dw[i,k] += m2.w[k,j] * b
-                              m2.dw[k,j] += m1.w[i,k] * b
-                          end
-                      end
-                  end
-              end )
+                #  m1.dw : m1n x m1d 
+                # out.dw : m1n x m2d
+                #   m2.w : m1d x m2d
+                # m1.dw += out.dw * m2.w'
+
+                #  m2.dw : m1d x m2d 
+                # out.dw : m1n x m2d
+                #   m1.w : m1n x m1d
+                # mw.dw += m1.w' * out.dw
+                @inbounds for i = 1:m1.n, j = 1:m2.d
+                    b = out.dw[i,j]
+                    for k = 1:m1.d # m1's num col
+                        m1.dw[i,k] += m2.w[k,j] * b
+
+                        m2.dw[k,j] += m1.w[i,k] * b
+                    end
+                end
+            end )
     end
     return out
 end
 
 function add(g::Graph, m1::NNMatrix, m2::NNMatrix)
-    out = NNMatrix(m1.n, m1.d)
-    out.w = m1.w .+ m2.w
+    out = NNMatrix(m1.n, m1.d, m1.w + m2.w, zeros(m1.n, m1.d))
     if g.doBackprop
         push!(g.backprop,
             function ()
@@ -123,8 +111,7 @@ function add(g::Graph, m1::NNMatrix, m2::NNMatrix)
 end
 
 function eltmul(g::Graph, m1::NNMatrix, m2::NNMatrix) # element-wise multiplication
-    out = NNMatrix(m1.n, m2.d)
-    out.w = m1.w .* m2.w
+    out = NNMatrix(m1.n, m2.d, m1.w .* m2.w, zeros(m1.n, m2.d))
     # backprop function
     if g.doBackprop
         push!(g.backprop,

--- a/src/recurrent.jl
+++ b/src/recurrent.jl
@@ -3,8 +3,8 @@ abstract Model # this is either an LSTM or RNN
 type NNMatrix # Neural net layer's weights & gradients
     n::Int
     d::Int
-    w::Array{Float64,2} # matix of weights
-    dw::Array{Float64,2} # matix of gtadients
+    w::Matrix{Float64} # matix of weights
+    dw::Matrix{Float64} # matix of gtadients
     NNMatrix(n::Int) = new(n, 1, zeros(n), zeros(n))
     NNMatrix(n::Int, d::Int) = new(n, d, zeros(n,d), zeros(n,d))
     NNMatrix(n::Int, d::Int, w::Array, dw::Array) = new(n, d, w, dw)

--- a/src/recurrent.jl
+++ b/src/recurrent.jl
@@ -3,8 +3,8 @@ abstract Model # this is either an LSTM or RNN
 type NNMatrix # Neural net layer's weights & gradients
     n::Int
     d::Int
-    w::Array # matix of weights
-    dw::Array # matix of gtadients
+    w::Array{Float64,2} # matix of weights
+    dw::Array{Float64,2} # matix of gtadients
     NNMatrix(n::Int) = new(n, 1, zeros(n), zeros(n))
     NNMatrix(n::Int, d::Int) = new(n, d, zeros(n,d), zeros(n,d))
     NNMatrix(n::Int, d::Int, w::Array, dw::Array) = new(n, d, w, dw)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -1,14 +1,14 @@
 type Solver
-   decayrate::FloatingPoint
-   smootheps::FloatingPoint
+   decayrate::Float64
+   smootheps::Float64
    stepcache::Array{NNMatrix,1}
    Solver() = new(0.999, 1e-8, Array(NNMatrix,0))
 end
 
-function step(solver::Solver, model::Model, stepsize::FloatingPoint, regc::FloatingPoint, clipval::FloatingPoint)
+function step(solver::Solver, model::Model, stepsize::Float64, regc::Float64, clipval::Float64)
 
     # perform parameter update
-    solverstats = Array(FloatingPoint,0)
+    solverstats = Array(Float64,0)
     numclipped = 0
     numtot = 0
 


### PR DESCRIPTION
Hi @Andy-P, I read your slide deck and found it pretty interesting.

The design right now is not exactly Julian, but I thought there might be some easy performance wins.

I set a seed at the top of `example.jl` and then ran for `maxiters` to warm up, then timed the second `maxiters`. First commit improves run time for this second bunch from 

```
elapsed time: 9.979846892 seconds (4465378136 bytes allocated, 18.29% gc time)
```

to

```
elapsed time: 0.671702053 seconds (378648984 bytes allocated, 21.77% gc time)
```

I'm hoping to get some more!
I'm working just on Julia 0.3, no idea about 0.4
